### PR TITLE
Allow Response Streaming from Generators

### DIFF
--- a/ckanext/csrf_filter/plugin.py
+++ b/ckanext/csrf_filter/plugin.py
@@ -3,6 +3,7 @@
 """
 
 from logging import getLogger
+from types import GeneratorType
 
 from ckan import plugins
 from ckan.plugins import implements, toolkit
@@ -95,6 +96,10 @@ class CSRFFilterPlugin(plugins.SingletonPlugin):
         def set_csrf_token(response):
             """ Apply a CSRF token to all response bodies.
             """
+            if hasattr(response, 'response') \
+            and isinstance(response.response, GeneratorType):
+                return response
+
             response.direct_passthrough = False
             anti_csrf.apply_token(response)
             return response

--- a/ckanext/csrf_filter/plugin.py
+++ b/ckanext/csrf_filter/plugin.py
@@ -97,7 +97,7 @@ class CSRFFilterPlugin(plugins.SingletonPlugin):
             """ Apply a CSRF token to all response bodies.
             """
             if hasattr(response, 'response') \
-            and isinstance(response.response, GeneratorType):
+                    and isinstance(response.response, GeneratorType):
                 return response
 
             response.direct_passthrough = False


### PR DESCRIPTION
feat(views): allow flask response streams;

- Allow response generators to return and not be edited to insert any token.